### PR TITLE
Add nu-ebpf crate for kprobe codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,6 +3770,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ebpf"
+version = "0.104.2"
+dependencies = [
+ "nu-protocol",
+]
+
+[[package]]
 name = "nu-engine"
 version = "0.104.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ members = [
   "crates/nu_plugin_formats",
   "crates/nu_plugin_polars",
   "crates/nu_plugin_stress_internals",
+  "crates/nu-ebpf",
   "crates/nu-std",
   "crates/nu-table",
   "crates/nu-term-grid",

--- a/crates/nu-ebpf/Cargo.toml
+++ b/crates/nu-ebpf/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+authors = ["The Nushell Project Developers"]
+description = "eBPF code generation utilities for Nushell"
+edition = "2024"
+license = "MIT"
+name = "nu-ebpf"
+version = "0.104.2"
+repository = "https://github.com/nushell/nushell"
+
+[lib]
+bench = false
+
+[dependencies]
+nu-protocol = { path = "../nu-protocol", version = "0.104.2" }
+
+[lints]
+workspace = true

--- a/crates/nu-ebpf/README.md
+++ b/crates/nu-ebpf/README.md
@@ -1,0 +1,6 @@
+# nu-ebpf
+
+Utilities for generating Rust source for eBPF programs used by Nushell.
+
+This crate is currently experimental and only provides helpers for code
+generation. It is not meant to be consumed outside of Nushell internals.

--- a/crates/nu-ebpf/src/lib.rs
+++ b/crates/nu-ebpf/src/lib.rs
@@ -1,0 +1,23 @@
+#![doc = include_str!("../README.md")]
+
+use nu_protocol::ast::Block;
+
+/// Generate Rust source for a kprobe eBPF program.
+///
+/// Currently this function ignores the `code` parameter and returns a
+/// hard-coded program that prints "hello" when the probe is hit.
+pub fn generate_kprobe(_code: &Block, fn_name: &str) -> String {
+    format!(
+        r#"use aya_bpf::macros::kprobe;
+use aya_bpf::programs::KProbeContext;
+use aya_log_ebpf::info;
+
+#[kprobe(name = "{name}")]
+pub fn {name}(ctx: KProbeContext) -> u32 {{
+    info!(&ctx, "hello");
+    0
+}}
+"#,
+        name = fn_name
+    )
+}


### PR DESCRIPTION
## Summary
- add new `nu-ebpf` internal crate
- expose `generate_kprobe` function for Aya-based probe templates
- register the crate in the workspace

## Testing
- `cargo check -p nu-ebpf`