### PR TITLE
Add placeholder ebpf command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -455,6 +455,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             JobId,
             JobTag,
             Job,
+            BpfKprobe,
         };
 
         #[cfg(not(target_family = "wasm"))]

--- a/crates/nu-command/src/ebpf/bpf_kprobe.rs
+++ b/crates/nu-command/src/ebpf/bpf_kprobe.rs
@@ -1,0 +1,69 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct BpfKprobe;
+
+impl Command for BpfKprobe {
+    fn name(&self) -> &str {
+        "bpf_kprobe"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("bpf_kprobe")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .required(
+                "function",
+                SyntaxShape::String,
+                "Kernel function name to probe.",
+            )
+            .required(
+                "handler",
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                "Closure to run when the probe is triggered.",
+            )
+            .category(Category::Experimental)
+    }
+
+    fn description(&self) -> &str {
+        "Attach a kprobe to a kernel function"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["ebpf", "kprobe"]
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Err(ShellError::UnsupportedInput {
+            msg: "bpf_kprobe is not implemented".to_string(),
+            input: "value originates from here".into(),
+            msg_span: call.head,
+            input_span: call.head,
+        })
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Attach kprobe (not implemented)",
+            example: "bpf_kprobe \"do_sys_open\" {|ctx| echo $ctx }",
+            result: None,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(BpfKprobe {})
+    }
+}

--- a/crates/nu-command/src/ebpf/mod.rs
+++ b/crates/nu-command/src/ebpf/mod.rs
@@ -1,0 +1,3 @@
+mod bpf_kprobe;
+
+pub use bpf_kprobe::BpfKprobe;

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -6,6 +6,7 @@ mod conversions;
 mod date;
 mod debug;
 mod default_context;
+mod ebpf;
 mod env;
 mod example_test;
 mod experimental;
@@ -41,6 +42,7 @@ pub use conversions::*;
 pub use date::*;
 pub use debug::*;
 pub use default_context::*;
+pub use ebpf::*;
 pub use env::*;
 #[cfg(test)]
 pub use example_test::{test_examples, test_examples_with_commands};

--- a/crates/nu-command/tests/commands/bpf_kprobe.rs
+++ b/crates/nu-command/tests/commands/bpf_kprobe.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn help_lists_bpf_kprobe() {
+    let actual = nu!("help commands | where name == bpf_kprobe | length");
+    assert_eq!(actual.out, "1");
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -4,6 +4,7 @@ mod any;
 mod append;
 mod assignment;
 mod base;
+mod bpf_kprobe;
 mod break_;
 mod bytes;
 mod cal;


### PR DESCRIPTION
## Summary
- add new ebpf module with `bpf_kprobe` command stub
- register command in default context
- expose ebpf commands from crate root
- test that `bpf_kprobe` shows up in `help commands`

## Testing
- `cargo test -p nu-command --offline` *(fails: failed to download crates)*